### PR TITLE
Fix to back link from commodity page

### DIFF
--- a/dit_helpdesk/commodities/templates/commodities/commodity_detail.html
+++ b/dit_helpdesk/commodities/templates/commodities/commodity_detail.html
@@ -21,7 +21,7 @@
         <div id="app-commodity-overview">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
-                    <a href="{% url 'search:search-commodity' country_code=selected_origin_country.lower %}" class="govuk-back-link govuk-!-margin-bottom-7 govuk-!-margin-top-3">Back</a>
+                    <a href="{{ back_link_url }}" class="govuk-back-link govuk-!-margin-bottom-7 govuk-!-margin-top-3">Back</a>
 
                     <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Export
                         {% for commodity_code_segment in commodity.commodity_code_split %}{{ commodity_code_segment }}{% if not forloop.last %}.{% endif %}{% endfor %}

--- a/dit_helpdesk/commodities/views.py
+++ b/dit_helpdesk/commodities/views.py
@@ -87,7 +87,12 @@ def commodity_detail(request, commodity_code, country_code):
     chapter = heading.chapter
     section = chapter.section
 
+    referer = reverse('search:search-commodity', args=[country_code])
+    if 'HTTP_REFERER' in request.META:
+        referer = request.META['HTTP_REFERER']
+
     context = {
+        "back_link_url": referer,
         "selected_origin_country": country.country_code,
         "commodity": commodity,
         "selected_origin_country_name": country.name,


### PR DESCRIPTION
Approach is
- If document.referer has a value use that for the back link
- If document.referer is blank (which is what happens if visitor has bookmarked the page) back goes back to the country page