### PR TITLE
Fix select country error message

### DIFF
--- a/dit_helpdesk/contact/views.py
+++ b/dit_helpdesk/contact/views.py
@@ -2,7 +2,6 @@ import logging
 
 from directory_forms_api_client import helpers
 from django.conf import settings
-from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.template.loader import get_template
@@ -72,8 +71,8 @@ class ContactFormWizardView(SessionWizardView):
     def dispatch(self, request, *args, **kwargs):
 
         if "origin_country" not in request.session:
-            messages.error(request, "Enter a country")
-            return redirect(reverse("choose-country"))
+            # messages.error(request, "Enter a country")
+            return redirect(reverse("choose-country") + "?select-country")
 
         return super(ContactFormWizardView, self).dispatch(request, *args, **kwargs)
 

--- a/dit_helpdesk/countries/views.py
+++ b/dit_helpdesk/countries/views.py
@@ -1,4 +1,3 @@
-from django.contrib.messages.context_processors import get_messages
 from django.shortcuts import render, redirect
 from django.urls import reverse
 
@@ -40,9 +39,9 @@ def choose_country_view(request):
 
     context = {"country_options": [(c.country_code, c.name) for c in countries]}
 
-    errorSummaryMessage = "Enter a country"
-    if errorSummaryMessage in [message.message for message in get_messages(request)]:
+    if 'select-country' in request.GET:
         context["isError"] = True
+        errorSummaryMessage = "Enter a country"
         context["errorSummaryMessage"] = errorSummaryMessage
         context["errorInputMessage"] = errorSummaryMessage
 


### PR DESCRIPTION
This PR removes the depnedency on the django messages framework and instead toggles a "select country" error mesage using a querystring parameter ?select-country