### PR TITLE
Add explicit action to commodity search form

### DIFF
--- a/dit_helpdesk/search/templates/search/commodity_search.html
+++ b/dit_helpdesk/search/templates/search/commodity_search.html
@@ -32,7 +32,7 @@
 
                 <div class="govuk-grid-column-full">
 
-                    <form id="commodity-search"
+                    <form id="commodity-search" action="{% url 'search:search-commodity' country_code=country_code %}"
                           class="govuk-!-padding-bottom-8" name="commodity_search" method="get">
 
                         {% if form_q_error %}


### PR DESCRIPTION
This makes all searches, regardless of the page the search is started from, go to the same results