### PR TITLE
TSS-253 Improve test coverage in TWUK

### DIFF
--- a/circleci.Dockerfile
+++ b/circleci.Dockerfile
@@ -16,7 +16,7 @@ VOLUME /reports
 ADD . /app/
 
 RUN pip install pipenv
-RUN pipenv lock -r > requirements.txt
+RUN pipenv requirements > requirements.txt
 RUN pip install -r requirements.txt
 
 CMD /app/start.sh

--- a/dit_helpdesk/commodities/tests/test_models.py
+++ b/dit_helpdesk/commodities/tests/test_models.py
@@ -93,6 +93,82 @@ class CommodityTestCase(TestCase):
             self.commodity.commodity_code_split, ["0101", "21", "00", "00"]
         )
 
+    def test_short_formatted_commodity_code(self):
+        self.assertEqual(
+            self.commodity.short_formatted_commodity_code, "0101.21"
+        )
+
+    def test_get_chapter(self):
+        chapter: Chapter = self.commodity.get_chapter()
+        self.assertIsInstance(chapter, Chapter)
+        self.assertEqual(
+            chapter.chapter_code, "0100000000"
+        )
+
+    def test_get_hierarchy_context_ids(self):
+        chapter_id, heading_id, subheading_id, commodity_id = self.commodity.get_hierarchy_context_ids()
+        self.assertEquals(chapter_id, self.chapter.id)
+        self.assertEquals(heading_id, self.heading.id)
+        self.assertEquals(subheading_id, self.subheading.id)
+        self.assertEquals(commodity_id, self.commodity.id)
+
+    def test_get_commodity_object_path(self):
+        object_path = self.commodity.get_commodity_object_path()
+
+        self.assertIsInstance(object_path[0][0], Commodity)
+        self.assertFalse(object_path[1])
+        self.assertIsInstance(object_path[2][0], SubHeading)
+        self.assertIsInstance(object_path[3][0], Heading)
+        self.assertIsInstance(object_path[4][0], Chapter)
+        self.assertIsInstance(object_path[5][0], Section)
+
+    def test_ancestor_data(self):
+        ancestor_data = self.commodity.ancestor_data
+        expected_ancestor_data = json.dumps([
+            [
+                {
+                    "id": self.section.id,
+                    "description": self.section.title,
+                    "commodity_code": self.section.roman_numeral,
+                    "type": "section"
+                },
+            ],
+            [
+                {
+                    "id": self.chapter.id,
+                    "description": self.chapter.description,
+                    "commodity_code": self.chapter.commodity_code,
+                    "type": "chapter"
+                },
+            ],
+            [
+                {
+                    "id": self.heading.id,
+                    "description": self.heading.description,
+                    "commodity_code": self.heading.commodity_code,
+                    "type": "heading"
+                },
+            ],
+            [
+                {
+                    "id": self.subheading.id,
+                    "description": self.subheading.description,
+                    "commodity_code": self.subheading.commodity_code,
+                    "type": "sub_heading"
+                },
+            ],
+            [
+                {
+                    "id": self.commodity.id,
+                    "description": self.commodity.description,
+                    "commodity_code": self.commodity.commodity_code,
+                    "type": "commodity"
+                },
+            ],
+        ])
+        self.maxDiff = None
+        self.assertEqual(ancestor_data, expected_ancestor_data)
+
     def test_tts_json_is_a_string_representing_a_json_object(self):
         self.assertTrue(isinstance(self.commodity.tts_json, str))
 

--- a/dit_helpdesk/commodities/tests/test_models.py
+++ b/dit_helpdesk/commodities/tests/test_models.py
@@ -94,19 +94,20 @@ class CommodityTestCase(TestCase):
         )
 
     def test_short_formatted_commodity_code(self):
-        self.assertEqual(
-            self.commodity.short_formatted_commodity_code, "0101.21"
-        )
+        self.assertEqual(self.commodity.short_formatted_commodity_code, "0101.21")
 
     def test_get_chapter(self):
         chapter: Chapter = self.commodity.get_chapter()
         self.assertIsInstance(chapter, Chapter)
-        self.assertEqual(
-            chapter.chapter_code, "0100000000"
-        )
+        self.assertEqual(chapter.chapter_code, "0100000000")
 
     def test_get_hierarchy_context_ids(self):
-        chapter_id, heading_id, subheading_id, commodity_id = self.commodity.get_hierarchy_context_ids()
+        (
+            chapter_id,
+            heading_id,
+            subheading_id,
+            commodity_id,
+        ) = self.commodity.get_hierarchy_context_ids()
         self.assertEquals(chapter_id, self.chapter.id)
         self.assertEquals(heading_id, self.heading.id)
         self.assertEquals(subheading_id, self.subheading.id)
@@ -124,48 +125,50 @@ class CommodityTestCase(TestCase):
 
     def test_ancestor_data(self):
         ancestor_data = self.commodity.ancestor_data
-        expected_ancestor_data = json.dumps([
+        expected_ancestor_data = json.dumps(
             [
-                {
-                    "id": self.section.id,
-                    "description": self.section.title,
-                    "commodity_code": self.section.roman_numeral,
-                    "type": "section"
-                },
-            ],
-            [
-                {
-                    "id": self.chapter.id,
-                    "description": self.chapter.description,
-                    "commodity_code": self.chapter.commodity_code,
-                    "type": "chapter"
-                },
-            ],
-            [
-                {
-                    "id": self.heading.id,
-                    "description": self.heading.description,
-                    "commodity_code": self.heading.commodity_code,
-                    "type": "heading"
-                },
-            ],
-            [
-                {
-                    "id": self.subheading.id,
-                    "description": self.subheading.description,
-                    "commodity_code": self.subheading.commodity_code,
-                    "type": "sub_heading"
-                },
-            ],
-            [
-                {
-                    "id": self.commodity.id,
-                    "description": self.commodity.description,
-                    "commodity_code": self.commodity.commodity_code,
-                    "type": "commodity"
-                },
-            ],
-        ])
+                [
+                    {
+                        "id": self.section.id,
+                        "description": self.section.title,
+                        "commodity_code": self.section.roman_numeral,
+                        "type": "section",
+                    },
+                ],
+                [
+                    {
+                        "id": self.chapter.id,
+                        "description": self.chapter.description,
+                        "commodity_code": self.chapter.commodity_code,
+                        "type": "chapter",
+                    },
+                ],
+                [
+                    {
+                        "id": self.heading.id,
+                        "description": self.heading.description,
+                        "commodity_code": self.heading.commodity_code,
+                        "type": "heading",
+                    },
+                ],
+                [
+                    {
+                        "id": self.subheading.id,
+                        "description": self.subheading.description,
+                        "commodity_code": self.subheading.commodity_code,
+                        "type": "sub_heading",
+                    },
+                ],
+                [
+                    {
+                        "id": self.commodity.id,
+                        "description": self.commodity.description,
+                        "commodity_code": self.commodity.commodity_code,
+                        "type": "commodity",
+                    },
+                ],
+            ]
+        )
         self.maxDiff = None
         self.assertEqual(ancestor_data, expected_ancestor_data)
 

--- a/dit_helpdesk/cookies/tests/test_templatetags.py
+++ b/dit_helpdesk/cookies/tests/test_templatetags.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+from django.template import Template, Context
+from django.test import TestCase, override_settings
+
+expected_value_with_setting = "expected value"
+expected_content_for_missing_setting = "<!-- missing GTM container id -->"
+
+
+class CoookieTemplateTagTestCase(TestCase):
+    """
+    Test the templatetags return the expected content
+    when the required setting is and isn't present
+    """
+
+    @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
+    def test_google_tag_manager_templatetag_with_setting(self):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager %}
+        """)
+        content = template.render(Context({}))
+        self.assertIn(expected_value_with_setting, content)
+
+
+    @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
+    @mock.patch("cookies.templatetags.gtm.render_gtm_template")
+    def test_google_tag_manager_templatetag_renders_main_template(self, mock_render):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager %}
+        """)
+        template.render(Context({}))
+        mock_render.assert_called_with("gtm.html")
+
+    @override_settings(HELPDESK_GA_GTM=None)
+    def test_google_tag_manager_templatetag_without_setting(self):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager %}
+        """)
+        content = template.render(Context({}))
+        self.assertIn(expected_content_for_missing_setting, content)
+
+    @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
+    def test_google_tag_manager_noscript_templatetag_with_setting(self):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager_noscript %}
+        """)
+        content = template.render(Context({}))
+        self.assertIn(expected_value_with_setting, content)
+
+    @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
+    @mock.patch("cookies.templatetags.gtm.render_gtm_template")
+    def test_google_tag_manager_noscript_templatetag_renders_main_template(self, mock_render):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager_noscript %}
+        """)
+        template.render(Context({}))
+        mock_render.assert_called_with("gtm_noscript.html")
+
+    @override_settings(HELPDESK_GA_GTM=None)
+    def test_google_tag_manager_noscript_templatetag_without_setting(self):
+        template = Template(template_string="""
+            {% load gtm %}
+            {% google_tag_manager_noscript %}
+        """)
+        content = template.render(Context({}))
+        self.assertIn(expected_content_for_missing_setting, content)
+

--- a/dit_helpdesk/cookies/tests/test_templatetags.py
+++ b/dit_helpdesk/cookies/tests/test_templatetags.py
@@ -15,58 +15,70 @@ class CoookieTemplateTagTestCase(TestCase):
 
     @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
     def test_google_tag_manager_templatetag_with_setting(self):
-        template = Template(template_string="""
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager %}
-        """)
+        """
+        )
         content = template.render(Context({}))
         self.assertIn(expected_value_with_setting, content)
-
 
     @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
     @mock.patch("cookies.templatetags.gtm.render_gtm_template")
     def test_google_tag_manager_templatetag_renders_main_template(self, mock_render):
-        template = Template(template_string="""
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager %}
-        """)
+        """
+        )
         template.render(Context({}))
         mock_render.assert_called_with("gtm.html")
 
     @override_settings(HELPDESK_GA_GTM=None)
     def test_google_tag_manager_templatetag_without_setting(self):
-        template = Template(template_string="""
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager %}
-        """)
+        """
+        )
         content = template.render(Context({}))
         self.assertIn(expected_content_for_missing_setting, content)
 
     @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
     def test_google_tag_manager_noscript_templatetag_with_setting(self):
-        template = Template(template_string="""
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager_noscript %}
-        """)
+        """
+        )
         content = template.render(Context({}))
         self.assertIn(expected_value_with_setting, content)
 
     @override_settings(HELPDESK_GA_GTM=expected_value_with_setting)
     @mock.patch("cookies.templatetags.gtm.render_gtm_template")
-    def test_google_tag_manager_noscript_templatetag_renders_main_template(self, mock_render):
-        template = Template(template_string="""
+    def test_google_tag_manager_noscript_templatetag_renders_main_template(
+        self, mock_render
+    ):
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager_noscript %}
-        """)
+        """
+        )
         template.render(Context({}))
         mock_render.assert_called_with("gtm_noscript.html")
 
     @override_settings(HELPDESK_GA_GTM=None)
     def test_google_tag_manager_noscript_templatetag_without_setting(self):
-        template = Template(template_string="""
+        template = Template(
+            template_string="""
             {% load gtm %}
             {% google_tag_manager_noscript %}
-        """)
+        """
+        )
         content = template.render(Context({}))
         self.assertIn(expected_content_for_missing_setting, content)
-

--- a/readme.md
+++ b/readme.md
@@ -233,13 +233,19 @@ for coverage reports run any of the above commands via coverage e.g.
 coverage run manage.py test dit_helpdesk --settings=config.settings.test
 ```
 
-and then the reports can be generated
+and then the reports can be generated:
 ```
-coverage -d reports html
+coverage html
 ```
+will write the reports to `test-reports/coverage_html` (configured in `.coveragerc`).
 
-you will then be able to access the coverage report html from within your project folder's root
-from your host machine at /reports
+You will then be able to access the coverage report html from within your project folder's root
+from your host machine in `test-reports/coverage_html`.
+
+To write the reports to another folder, use:
+```
+coverage -d path/to/another_folder html
+```
 
 ##### Updating modules
 


### PR DESCRIPTION
Just some additional tests to help bump it up slightly.

The GTM template tag tests are interesting, as they show that sometimes function definitions and decorators will be marked as untested, possibly due to the way Node interacts with Coverage. This effect will skew our results downwards.

On the other hand, the commodities models tests show that there are definitely uncovered areas.